### PR TITLE
Add annotations to Buildkite Terraform plan steps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,12 @@ ARG SHFMT_VERSION=3.3.0
 ARG YQ_VERSION=4.9.3
 ARG SCHMA_VERSION=0.0.1
 ARG SNYK_VERSION=1.621.0
+ARG TERMINAL_TO_HTML_VERSION=3.6.1
+ARG BUILDKITE_AGENT_VERSION=3.32.0
 
 # Install OS packages.
 RUN apk add --no-cache \
-    bash ca-certificates curl git jq make ncurses openssh perl xz zip
+    bash ca-certificates curl git jq make ncurses openssh perl xz zip gzip
 
 # Install glibc compatibility for Alpine which is required to run AWS CLI V2. See comment here:
 # https://github.com/aws/aws-cli/issues/4685#issuecomment-615872019
@@ -64,6 +66,19 @@ RUN curl -Lso /usr/local/bin/schma \
 RUN curl -Lso /usr/local/bin/snyk \
   "https://github.com/snyk/snyk/releases/download/v${SNYK_VERSION}/snyk-alpine" \
   && chmod +x /usr/local/bin/snyk
+
+# Install terminal-to-html
+RUN curl -Lso terminal-to-html.gz \
+  https://github.com/buildkite/terminal-to-html/releases/download/v${TERMINAL_TO_HTML_VERSION}/terminal-to-html-${TERMINAL_TO_HTML_VERSION}-linux-amd64.gz \
+  && gunzip terminal-to-html.gz \
+  && mv terminal-to-html /usr/local/bin/terminal-to-html \
+  && chmod +x /usr/local/bin/terminal-to-html
+
+# Install the buildkite-agent
+RUN curl -Lso buildkite-agent.tar.gz \
+  https://github.com/buildkite/agent/releases/download/v${BUILDKITE_AGENT_VERSION}/buildkite-agent-linux-amd64-${BUILDKITE_AGENT_VERSION}.tar.gz \
+  && tar -xvf buildkite-agent.tar.gz \
+  && mv buildkite-agent /usr/local/bin/buildkite-agent
 
 # Install toolbox
 ADD bin "${TOOLBOX_HOME}/bin"

--- a/bin/toolbox.sh
+++ b/bin/toolbox.sh
@@ -62,6 +62,7 @@ case "${_arg_command1}" in
   buildkite)
     case "${_arg_command2}" in
       pipeline) bk_pipeline ;;
+      plan-annotate) bk_plan_annotate ;;
       *)
         die "Unrecognised Buildkite command: ${_arg_command2}"
         ;;

--- a/lib/args.m4
+++ b/lib/args.m4
@@ -34,6 +34,7 @@ Second-level command.
             - lint
           The 'buildkite' command accepts the following:
             - pipeline
+            - plan-annotate
           The 'shell' command accepts the following:
             - shfmt
             - shellcheck

--- a/lib/args.sh
+++ b/lib/args.sh
@@ -34,6 +34,7 @@ Second-level command.
             - lint
           The 'buildkite' command accepts the following:
             - pipeline
+            - plan-annotate
           The 'shell' command accepts the following:
             - shfmt
             - shellcheck

--- a/lib/buildkite.sh
+++ b/lib/buildkite.sh
@@ -405,8 +405,8 @@ bk_plan_annotate() {
   info_msg "Annotating build with plan output"
 
   local tf_plan_file="${build_dir}/terraform.tfplan"
-  if [[ -f "${_tf_plan_file}" ]]; then
-    is_all_no_ops=$(terraform show -json "${_tf_plan_file}" | jq '[.resource_changes[].change.actions] | flatten | all(. == "no-op")')
+  if [[ -f "${tf_plan_file}" ]]; then
+    is_all_no_ops=$(terraform show -json "${tf_plan_file}" | jq '[.resource_changes[].change.actions] | flatten | all(. == "no-op")')
     if [[ "${is_all_no_ops}" == "true" ]]; then
       buildkite-agent annotate "**${_arg_workspace}**: Successful plan with no changes" --style success --context "${_arg_workspace}"
     else
@@ -417,7 +417,7 @@ bk_plan_annotate() {
         echo -e '<details>'
         echo -e '<summary>Plan output</summary>'
         echo -e '<pre class="term"><code>'
-        terraform show "${_tf_plan_file}" | terminal-to-html
+        terraform show "${tf_plan_file}" | terminal-to-html
         echo -e '</code></pre>'
         echo -e '</details>'
       } | buildkite-agent annotate --context "${_arg_workspace}" --style info

--- a/lib/buildkite.sh
+++ b/lib/buildkite.sh
@@ -406,6 +406,7 @@ bk_plan_annotate() {
 
   local tf_plan_file="${build_dir}/terraform.tfplan"
   if [[ -f "${tf_plan_file}" ]]; then
+    local is_all_no_ops
     is_all_no_ops=$(terraform show -json "${tf_plan_file}" | jq '[.resource_changes[].change.actions] | flatten | all(. == "no-op")')
     if [[ "${is_all_no_ops}" == "true" ]]; then
       buildkite-agent annotate "**${_arg_workspace}**: Successful plan with no changes" --style success --context "${_arg_workspace}"

--- a/lib/buildkite.sh
+++ b/lib/buildkite.sh
@@ -412,6 +412,7 @@ bk_plan_annotate() {
     else
       buildkite-agent annotate "**${_arg_workspace}**: Successful plan with changes" --style info --context "${_arg_workspace}"
       {
+        echo -e "**${_arg_workspace}**: Successful plan with changes"
         echo -e ''
         echo -e '<details>'
         echo -e '<summary>Plan output</summary>'
@@ -419,10 +420,13 @@ bk_plan_annotate() {
         terraform show "${_tf_plan_file}" | terminal-to-html
         echo -e '</code></pre>'
         echo -e '</details>'
-      } | buildkite-agent annotate --append --context "${_arg_workspace}"
+      } | buildkite-agent annotate --context "${_arg_workspace}" --style info
     fi
   else
-    buildkite-agent annotate "**${_arg_workspace}**: Error while planning" --style error --context "${_arg_workspace}"
-    buildkite-agent annotate "Consult [the failing job for more information](#${BUILDKITE_JOB_ID})" --style error --context "${_arg_workspace}" --append
+    {
+      echo -e "**${_arg_workspace}**: Error while planning"
+      echo -e ''
+      echo -e "Consult [the failing job](#${BUILDKITE_JOB_ID}) for more information"
+    } | buildkite-agent annotate --style error --context "${_arg_workspace}"
   fi
 }

--- a/lib/buildkite.sh
+++ b/lib/buildkite.sh
@@ -387,7 +387,7 @@ EOF
 }
 
 ##
-## Generate an annotation for the build based on the plan result
+## Generate an annotation for the build based on the plan result.
 ##
 ## This function looks for a plan file at "${build_dir}/terraform.tfplan"
 ## If there is no file, we assume the plan failed, and we create an error annotation with a link to the failed job

--- a/lib/terraform.sh
+++ b/lib/terraform.sh
@@ -173,7 +173,8 @@ bk_plan_annotate() {
     else
       buildkite-agent annotate "**${_arg_workspace}**: Successful plan with changes" --style info --context "${_arg_workspace}"
     fi
-    { echo -e ''
+    {
+      echo -e ''
       echo -e '<details>'
       echo -e '<summary>Plan output</summary>'
       echo -e '<pre class="term"><code>'

--- a/lib/terraform.sh
+++ b/lib/terraform.sh
@@ -118,9 +118,7 @@ tf_plan() {
 
   # Create a Terraform plan.
   info_msg "Creating Terraform plan for workspace ${_arg_workspace}"
-  terraform plan -out="${_tf_plan_file}" -detailed-exitcode
-  plan_return_code="$?"
-  bk_plan_annotate "${plan_return_code}"
+  terraform plan -out="${_tf_plan_file}"
 }
 
 ##
@@ -133,9 +131,7 @@ tf_plan_destroy_local() {
   # Create a local Terraform destroy plan by operating on local state.
   info_msg "Creating local Terraform destroy plan for workspace ${_arg_workspace}"
   terraform state pull > "${_tf_state_file}"
-  terraform plan -destroy -state="${_tf_state_file}" -lock=false -out="${_tf_plan_file}" -detailed-exitcode
-  plan_return_code="$?"
-  bk_plan_annotate "${plan_return_code}"
+  terraform plan -destroy -state="${_tf_state_file}" -lock=false -out="${_tf_plan_file}"
 }
 
 ##
@@ -148,41 +144,7 @@ tf_plan_local() {
   # Create a local Terraform plan by operating on local state.
   info_msg "Creating local Terraform plan for workspace ${_arg_workspace}"
   terraform state pull > "${_tf_state_file}"
-  terraform plan -state="${_tf_state_file}" -lock=false -out="${_tf_plan_file}" -detailed-exitcode
-  plan_return_code="$?"
-  bk_plan_annotate "${plan_return_code}"
-}
-
-##
-## Generate an annotation based on a plan result and a plan file
-##
-## This function assumes that a plan file exists at ${_tf_plan_file}, and accepts a single argument which is the return
-## code of terraform plan -detailed-exitcode
-##
-bk_plan_annotate() {
-  local plan_return_code
-  plan_return_code="${1}"
-
-  info_msg "Annotating build with plan output"
-
-  if [[ "${plan_return_code}" -eq "0" ]]; then
-    buildkite-agent annotate "**${_arg_workspace}**: Successful plan with no changes" --style success --context "${_arg_workspace}"
-  else
-    if [[ "${plan_return_code}" -eq "1" ]]; then
-      buildkite-agent annotate "**${_arg_workspace}**: Error while planning" --style error --context "${_arg_workspace}"
-    else
-      buildkite-agent annotate "**${_arg_workspace}**: Successful plan with changes" --style info --context "${_arg_workspace}"
-    fi
-    {
-      echo -e ''
-      echo -e '<details>'
-      echo -e '<summary>Plan output</summary>'
-      echo -e '<pre class="term"><code>'
-      terraform show "${_tf_plan_file}" | terminal-to-html
-      echo -e '</code></pre>'
-      echo -e '</details>'
-    } | buildkite-agent annotate --append --context "${_arg_workspace}"
-  fi
+  terraform plan -state="${_tf_state_file}" -lock=false -out="${_tf_plan_file}"
 }
 
 ##

--- a/toolbox.mk
+++ b/toolbox.mk
@@ -42,6 +42,8 @@ _toolbox = \
 	docker run --rm $2 \
 		-e TOOLBOX_CONFIG_FILE \
 		-e BUILDKITE_PIPELINE_SLUG \
+		-e BUILDKITE_JOB_ID \
+		-e BUILDKITE_AGENT_ACCESS_TOKEN \
 		-e TERM \
 		-v "$$(pwd):/work" \
 		-v "$(HOME)/.aws:/root/.aws" \

--- a/toolbox.mk
+++ b/toolbox.mk
@@ -172,13 +172,16 @@ terraform-destroy terraform-console: terraform-ensure-workspace
 	@$(call toolbox_tty,toolbox -w "$(WORKSPACE)" -s "$(SKIP_INIT)" terraform "$(@:terraform-%=%)")
 
 ##
-## Buildkite targets.
+## Buildkite targets that DO require a workspace
 ##
 .PHONY: buildkite-pipeline
 buildkite-pipeline:
 	@$(call banner,$@)
 	@$(call toolbox,toolbox buildkite "$(@:buildkite-%=%)")
 
+##
+## Buildkite targets that DON'T require a workspace
+##
 .PHONY: buildkite-plan-annotate
 buildkite-plan-annotate:
 	@$(call banner,$@)

--- a/toolbox.mk
+++ b/toolbox.mk
@@ -174,10 +174,15 @@ terraform-destroy terraform-console: terraform-ensure-workspace
 ##
 ## Buildkite targets.
 ##
-.PHONY: buildkite-pipeine
+.PHONY: buildkite-pipeline
 buildkite-pipeline:
 	@$(call banner,$@)
 	@$(call toolbox,toolbox buildkite "$(@:buildkite-%=%)")
+
+.PHONY: buildkite-plan-annotate
+buildkite-plan-annotate:
+	@$(call banner,$@)
+	@$(call toolbox,toolbox -w "$(WORKSPACE)" buildkite "$(@:buildkite-%=%)")
 
 ##
 ## Shell targets.


### PR DESCRIPTION
This adds pretty looking annotations to the Buildkite build steps when
some sort of plan is done.

Based on the detailed exitcode, we create a success, info or error style
annotation.

For success with changes plans, we embed a human readable version of the changes in the annotation.
For error plans, we link to the erroring job

Closes #4 