### PR TITLE
Allow Toolbox to execute Docker commands by mapping docker.sock

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ ARG BUILDKITE_AGENT_VERSION=3.32.0
 
 # Install OS packages.
 RUN apk add --no-cache \
-    bash ca-certificates curl git jq make ncurses openssh perl xz zip gzip
+    bash ca-certificates curl docker git jq make ncurses openssh perl xz zip gzip
 
 # Install glibc compatibility for Alpine which is required to run AWS CLI V2. See comment here:
 # https://github.com/aws/aws-cli/issues/4685#issuecomment-615872019

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ push-latest:
 .PHONY: pin
 pin: $(build_dir)
 	@$(call banner,$@)
-	@sed "s/TOOLBOX_VERSION := .*/TOOLBOX_VERSION := $(RELEASE_VERSION)/" toolbox.mk > $(build_dir)/toolbox.mk
+	@sed "s/TOOLBOX_VERSION ?= .*/TOOLBOX_VERSION ?= $(RELEASE_VERSION)/" toolbox.mk > $(build_dir)/toolbox.mk
 	@echo "Created $(RELEASE_ARCHIVE) pinned to version $(RELEASE_VERSION)" >&2
 
 ##

--- a/toolbox.mk
+++ b/toolbox.mk
@@ -1,5 +1,12 @@
 # Version of Toolbox to use.
-TOOLBOX_VERSION := latest
+TOOLBOX_VERSION ?= latest
+
+# Toolbox Docker image.
+TOOLBOX_IMAGE ?= seek/toolbox:$(TOOLBOX_VERSION)
+
+# The TOOLBOX_CONFIG_FILE variable can be specified by the caller to override
+# the default config file locations.
+TOOLBOX_CONFIG_FILE ?=
 
 # The WORKSPACE variable is required by certain targets and should be
 # provided by the caller in the form `make target WORKSPACE=workspace`.
@@ -10,17 +17,10 @@ WORKSPACE ?=
 # Terraform has already been initialised for the project.
 SKIP_INIT ?= false
 
-# The TOOLBOX_CONFIG_FILE variable can be specified by the caller to override
-# the default config file locations.
-TOOLBOX_CONFIG_FILE ?=
-
 # The Buildkite pipeline slug is used when generating the pipeline document.
 # When running on an agent the BUILDKITE_PIPELINE_SLUG will be present.
 # A default value is set for local testing purposes.
 export BUILDKITE_PIPELINE_SLUG ?= $(shell basename $(shell pwd))
-
-# Toolbox Docker image.
-toolbox_image := seek/toolbox:$(TOOLBOX_VERSION)
 
 # Local build artifacts directory.
 build_dir := target
@@ -47,8 +47,9 @@ _toolbox = \
 		-e TERM \
 		-v "$$(pwd):/work" \
 		-v "$(HOME)/.aws:/root/.aws" \
+		-v "/var/run/docker.sock:/var/run/docker.sock" \
 		-w /work \
-		"$(toolbox_image)" $1
+		"$(TOOLBOX_IMAGE)" $1
 toolbox     = $(call _toolbox,$1)
 toolbox_tty = $(call _toolbox,$1,-ti)
 
@@ -80,6 +81,7 @@ define HELP
 | terraform-unlock             | Force unlocks the Terraform state. WORKSPACE must be specified.                  |
 |------------------------------+----------------------------------------------------------------------------------|
 | buildkite-pipeline           | Prints the generated Buildkite pipeline to stdout.                               |
+| buildkite-plan-annotate      | Annotates the current Buildkite pipeline with details of the Terraform plan.     |
 |------------------------------+----------------------------------------------------------------------------------|
 | shell-shfmt                  | Runs shfmt against shell files in the current repository.                        |
 | shell-shellcheck             | Runs shellcheck against shell files in the current repository.                   |


### PR DESCRIPTION
This PR maps in `docker.sock` as a volume so that Toolbox can access the Docker daemon on the host. This allows, for example, Terraform `null_resource`s to run Docker containers.

Other minor changes allow the TOOLBOX_VERSION and TOOLBOX_IMAGE to be overridden by the parent Makefile (sometimes useful for testing).