### PR TITLE
Switch plan annotations to link to changes instead of showing them

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,6 @@ ARG SHFMT_VERSION=3.3.0
 ARG YQ_VERSION=4.9.3
 ARG SCHMA_VERSION=0.0.1
 ARG SNYK_VERSION=1.621.0
-ARG TERMINAL_TO_HTML_VERSION=3.6.1
 ARG BUILDKITE_AGENT_VERSION=3.32.0
 
 # Install OS packages.
@@ -66,13 +65,6 @@ RUN curl -Lso /usr/local/bin/schma \
 RUN curl -Lso /usr/local/bin/snyk \
   "https://github.com/snyk/snyk/releases/download/v${SNYK_VERSION}/snyk-alpine" \
   && chmod +x /usr/local/bin/snyk
-
-# Install terminal-to-html
-RUN curl -Lso terminal-to-html.gz \
-  https://github.com/buildkite/terminal-to-html/releases/download/v${TERMINAL_TO_HTML_VERSION}/terminal-to-html-${TERMINAL_TO_HTML_VERSION}-linux-amd64.gz \
-  && gunzip terminal-to-html.gz \
-  && mv terminal-to-html /usr/local/bin/terminal-to-html \
-  && chmod +x /usr/local/bin/terminal-to-html
 
 # Install the buildkite-agent
 RUN curl -Lso buildkite-agent.tar.gz \

--- a/lib/buildkite.sh
+++ b/lib/buildkite.sh
@@ -393,8 +393,8 @@ EOF
 ## If there is no file, we assume the plan failed, and we create an error annotation with a link to the failed job.
 ## If there is a file, we inspect the .resource_changes[].change.actions fields for each resource.
 ## If all of these fields are "no-op", the plan has succeeded with no changes.
-## If any of these fields are not "no-op", the plan has succeeded with changes. In this case, we do a terraform show
-## and render these changes in the annotation.
+## If any of these fields are not "no-op", the plan has succeeded with changes, and we link to the job for further
+## inspection.
 ##
 bk_plan_annotate() {
   # Ensure that a workspace argument (-w/--workspace) was specified.
@@ -415,12 +415,7 @@ bk_plan_annotate() {
       {
         echo -e "**${_arg_workspace}**: Successful plan with changes"
         echo -e ''
-        echo -e '<details>'
-        echo -e '<summary>Plan output</summary>'
-        echo -e '<pre class="term"><code>'
-        terraform show "${tf_plan_file}" | terminal-to-html
-        echo -e '</code></pre>'
-        echo -e '</details>'
+        echo -e "Consult [the job](#${BUILDKITE_JOB_ID}) for more information"
       } | buildkite-agent annotate --context "${_arg_workspace}" --style info
     fi
   else


### PR DESCRIPTION
The rendering of the intended plan in the plan annotations didn't work
very well. It was hard to read due to presumably issues with how the
rendered output of the terminal-to-html output is handled.

This simplifies things a little, and just links off to the job when a
plan has changes, and the user can find the plan themselves. Not ideal,
but I think a little cleaner for the moment.

We still get the nice property of being able to immediately see the
outcome of the plans at the top of the build.
