### PR TITLE
Add annotations to regular plan steps

### DIFF
--- a/lib/buildkite.sh
+++ b/lib/buildkite.sh
@@ -150,7 +150,9 @@ _bk_tf_plan_steps() {
     cat << EOF
 - label: ":terraform: Plan [${workspace}]"
   branches: "${protected_branches}"
-  command: make terraform-plan WORKSPACE=${workspace}
+  command:
+  - make terraform-plan WORKSPACE=${workspace}
+  - make buildkite-plan-annotate WORKSPACE=${workspace}
   plugins:
   - artifacts#${_bk_artifacts_plugin_version}:
       upload: ${uploads}


### PR DESCRIPTION
I left this out in my other PR. The result is that we were only
annotating tentative plans, when it's really helpful to also annotate
the real plans.
