### PR TITLE
Add HOST_WORK_DIR and HOST_HOME_DIR

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,17 +180,6 @@ buildkite:
       to: target/package.zip
 ```
 
-## Environment Variables
-
-The following environment variables are available:
-
-- `HOST_ROOT_DIR`: the path of [toolbox.mk][02] normally situated in the root of the repository. When
-running docker from a makefile target you may need to mount a volume from the real host path into the
-docker container.
-- `HOST_HOME_DIR`: home directory of the current user running the makefile target. When running docker
-from a makefile target you may need to mount the home directory of the current user running the makefile
-target. Useful for mapping aws credential files into the docker container.
-
 <!-- Links -->
 [01]: Dockerfile
 [02]: toolbox.mk

--- a/README.md
+++ b/README.md
@@ -180,6 +180,17 @@ buildkite:
       to: target/package.zip
 ```
 
+## Environment Variables
+
+The following environment variables are available:
+
+- `HOST_ROOT_DIR`: the path of [toolbox.mk][02] normally situated in the root of the repository. When
+running docker from a makefile target you may need to mount a volume from the real host path into the
+docker container.
+- `HOST_HOME_DIR`: home directory of the current user running the makefile target. When running docker
+from a makefile target you may need to mount the home directory of the current user running the makefile
+target. Useful for mapping aws credential files into the docker container.
+
 <!-- Links -->
 [01]: Dockerfile
 [02]: toolbox.mk

--- a/toolbox.mk
+++ b/toolbox.mk
@@ -1,3 +1,13 @@
+# This needs to be the first entry
+# https://www.gnu.org/software/make/manual/html_node/Special-Variables.html#Special-Variables
+# When running docker from a makefile target you may need to mount a volume
+# from the real host path into the docker container.
+export HOST_ROOT_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+
+# When running docker from a makefile target you may need to mount the home directory
+# of the current user running the makefile target.
+export HOST_HOME_DIR := $(HOME)
+
 # Version of Toolbox to use.
 TOOLBOX_VERSION ?= latest
 
@@ -40,6 +50,8 @@ banner = \
 # Macros for executing running a command in the toolbox container.
 _toolbox = \
 	docker run --rm $2 \
+		-e HOST_ROOT_DIR \
+		-e HOST_HOME_DIR \
 		-e TOOLBOX_CONFIG_FILE \
 		-e BUILDKITE_PIPELINE_SLUG \
 		-e BUILDKITE_JOB_ID \

--- a/toolbox.mk
+++ b/toolbox.mk
@@ -1,13 +1,3 @@
-# This needs to be the first entry
-# https://www.gnu.org/software/make/manual/html_node/Special-Variables.html#Special-Variables
-# When running docker from a makefile target you may need to mount a volume
-# from the real host path into the docker container.
-export HOST_ROOT_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
-
-# When running docker from a makefile target you may need to mount the home directory
-# of the current user running the makefile target.
-export HOST_HOME_DIR := $(HOME)
-
 # Version of Toolbox to use.
 TOOLBOX_VERSION ?= latest
 
@@ -50,8 +40,8 @@ banner = \
 # Macros for executing running a command in the toolbox container.
 _toolbox = \
 	docker run --rm $2 \
-		-e HOST_ROOT_DIR \
-		-e HOST_HOME_DIR \
+		-e HOST_WORK_DIR=$(shell pwd) \
+		-e HOST_HOME_DIR=$(HOME) \
 		-e TOOLBOX_CONFIG_FILE \
 		-e BUILDKITE_PIPELINE_SLUG \
 		-e BUILDKITE_JOB_ID \


### PR DESCRIPTION
Add HOST_WORK_DIR and HOST_HOME_DIR environment variables

These can be used when calling docker from within a makefile target to map volumes to the original host.