### PR TITLE
Trap errors during annotate and continue anyway

### DIFF
--- a/lib/buildkite.sh
+++ b/lib/buildkite.sh
@@ -398,11 +398,15 @@ EOF
 ## If any of these fields are not "no-op", the plan has succeeded with changes, and we link to the job for further
 ## inspection.
 ##
+## If this function errors at all, we don't want it to cause the plan to fail.
+##
 bk_plan_annotate() {
   # Ensure that a workspace argument (-w/--workspace) was specified.
   if [[ -z "${_arg_workspace:-}" ]]; then
     die "No Terraform workspace specified. This command requires a --workspace argument."
   fi
+
+  trap 'error_msg "Error while annotating plan. INVESTIGATE THIS. Continuing anyway" && exit 0' ERR
 
   info_msg "Annotating build with plan output"
 

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -69,6 +69,19 @@ info_msg() {
 }
 
 ##
+## Pretty prints an error message.
+##
+error_msg() {
+  local msg="${1}"
+  local color_on color_off
+  if [[ -n "${TERM:-}" && "${TERM}" != dumb ]]; then
+    color_on="$(tput setaf 1)"
+    color_off="$(tput sgr0)"
+  fi
+  printf "%s\n" "${color_on:-}=> => ${msg}${color_off:-}" >&2
+}
+
+##
 ## Reads a config property from the config file or returns a default value (if provided).
 ## The property argument should be specified relative to the top-level " property
 ## and should not include a leading "." character.


### PR DESCRIPTION
This adds a trap for any errors that are encountered while annotating
the Buildkite build. This annotation is meant to be decorative only, and
shouldn't interrupt a build if it fails.