### PR TITLE
Expose pipeline steps as make targets for mixing and matching

### DIFF
--- a/bin/toolbox.sh
+++ b/bin/toolbox.sh
@@ -62,6 +62,10 @@ case "${_arg_command1}" in
   buildkite)
     case "${_arg_command2}" in
       pipeline) bk_pipeline ;;
+      pipeline-begin-steps) bk_pipeline_begin_steps ;;
+      pipeline-check-steps) bk_pipeline_check_steps ;;
+      pipeline-plan-steps) bk_tf_plan_steps ;;
+      pipeline-apply-steps) bk_tf_apply_steps ;;
       plan-annotate) bk_plan_annotate ;;
       *)
         die "Unrecognised Buildkite command: ${_arg_command2}"

--- a/lib/args.m4
+++ b/lib/args.m4
@@ -34,6 +34,10 @@ Second-level command.
             - lint
           The 'buildkite' command accepts the following:
             - pipeline
+            - pipeline-begin-steps
+            - pipeline-check-steps
+            - pipeline-plan-steps
+            - pipeline-apply-steps
             - plan-annotate
           The 'shell' command accepts the following:
             - shfmt

--- a/lib/args.sh
+++ b/lib/args.sh
@@ -34,6 +34,10 @@ Second-level command.
             - lint
           The 'buildkite' command accepts the following:
             - pipeline
+            - pipeline-begin-steps
+            - pipeline-check-steps
+            - pipeline-plan-steps
+            - pipeline-apply-steps
             - plan-annotate
           The 'shell' command accepts the following:
             - shfmt

--- a/lib/buildkite.sh
+++ b/lib/buildkite.sh
@@ -16,20 +16,30 @@ _bk_artifacts_plugin_version=v1.4.0
 ## Print the Buildkite pipeline to stdout.
 ##
 bk_pipeline() {
-  _bk_begin_steps
+  bk_pipeline_begin_steps
   _bk_tf_lint_step
   _bk_sh_lint_step
   _bk_tf_validate_step
   _bk_snyk_steps
   _bk_wait_step
-  _bk_tf_plan_steps
-  _bk_tf_apply_steps
+  bk_tf_plan_steps
+  bk_tf_apply_steps
+}
+
+##
+## Print all Buildkite pipeline lint and validate steps.
+##
+bk_pipeline_check_steps() {
+  _bk_tf_lint_step
+  _bk_sh_lint_step
+  _bk_tf_validate_step
+  _bk_snyk_steps
 }
 
 ##
 ## Print beginning of the Buildkite pipeline steps.
 ##
-_bk_begin_steps() {
+bk_pipeline_begin_steps() {
   echo 'steps:'
 }
 
@@ -159,7 +169,7 @@ _bk_tf_artifacts_plugin() {
 ##
 ## Print a Terraform plan step for each workspace.
 ##
-_bk_tf_plan_steps() {
+bk_tf_plan_steps() {
   local total_workspaces
   total_workspaces="$(_bk_tf_total_workspaces)"
   if [[ "${total_workspaces}" == 0 ]]; then
@@ -215,7 +225,7 @@ EOF
 ##
 ## Wait/Block -> Apply Non-Prod -> Wait/Block -> Apply Prod
 ##
-_bk_tf_apply_steps() {
+bk_tf_apply_steps() {
   local total_workspaces
   total_workspaces="$(_bk_tf_total_workspaces)"
   if [[ "${total_workspaces}" == 0 ]]; then

--- a/toolbox.mk
+++ b/toolbox.mk
@@ -57,42 +57,46 @@ toolbox_tty = $(call _toolbox,$1,-ti)
 
 # Help message printed by the help target.
 define HELP
-+------------------------------+----------------------------------------------------------------------------------+
-| Make Target                  | Description                                                                      |
-|------------------------------+----------------------------------------------------------------------------------|
-| help                         | Displays this help message.                                                      |
-| clean                        | Deletes the target/ and .terraform/ directories.                                 |
-|------------------------------+----------------------------------------------------------------------------------|
-| toolbox-version              | Prints Toolbox version information.                                              |
-| toolbox-upgrade              | Upgrades the version of Toolbox to the latest versioned release.                 |
-| toolbox-bash                 | Launch an interactive Bash shell in the Toolbox container.                       |
-|------------------------------+----------------------------------------------------------------------------------|
-| terraform-lint               | Lints Terraform files in the current repository.                                 |
-| terraform-init               | Initialises Terraform.                                                           |
-| terraform-validate           | Validates Terraform files in the current repository.                             |
-| terraform-workspace          | Selects the Terraform workspace. WORKSPACE must be specified.                    |
-| terraform-output             | Prints Terraform outputs in HCL format. WORKSPACE must be specified.             |
-| terraform-output-json        | Prints Terraform outputs in JSON format. WORKSPACE must be specified.            |
-| terraform-plan               | Creates a Terraform plan using remote state. WORKSPACE must be specified.        |
-| terraform-plan-destroy-local | Creates a Terraform destroy plan using local state. WORKSPACE must be specified. |
-| terraform-plan-local         | Creates a Terraform plan using local state. WORKSPACE must be specified.         |
-| terraform-apply              | Applies previously created Terraform plan. WORKSPACE must be specified.          |
-| terraform-refresh            | Refreshes remote Terraform state. WORKSPACE must be specified.                   |
-| terraform-destroy            | Destroys Terraform-managed infrastructure. WORKSPACE must be specified.          |
-| terraform-console            | Launches a Terraform console. WORKSPACE must be specified.                       |
-| terraform-unlock             | Force unlocks the Terraform state. WORKSPACE must be specified.                  |
-|------------------------------+----------------------------------------------------------------------------------|
-| buildkite-pipeline           | Prints the generated Buildkite pipeline to stdout.                               |
-| buildkite-plan-annotate      | Annotates the current Buildkite pipeline with details of the Terraform plan.     |
-|------------------------------+----------------------------------------------------------------------------------|
-| shell-shfmt                  | Runs shfmt against shell files in the current repository.                        |
-| shell-shellcheck             | Runs shellcheck against shell files in the current repository.                   |
-| shell-lint                   | Runs shfmt and shellcheck against shell files in the current repository.         |
-|------------------------------+----------------------------------------------------------------------------------|
-| snyk-project                 | Creates a project on the Snyk website for the current repository.                |
-| snyk-app-test                | Runs a Snyk application test.                                                    |
-| snyk-iac-test                | Runs a Snyk infrastructure test.                                                 |
-+------------------------------+----------------------------------------------------------------------------------+
++--------------------------------+----------------------------------------------------------------------------------+
+| Make Target                    | Description                                                                      |
+|--------------------------------+----------------------------------------------------------------------------------|
+| help                           | Displays this help message.                                                      |
+| clean                          | Deletes the target/ and .terraform/ directories.                                 |
+|--------------------------------+----------------------------------------------------------------------------------|
+| toolbox-version                | Prints Toolbox version information.                                              |
+| toolbox-upgrade                | Upgrades the version of Toolbox to the latest versioned release.                 |
+| toolbox-bash                   | Launch an interactive Bash shell in the Toolbox container.                       |
+|--------------------------------+----------------------------------------------------------------------------------|
+| terraform-lint                 | Lints Terraform files in the current repository.                                 |
+| terraform-init                 | Initialises Terraform.                                                           |
+| terraform-validate             | Validates Terraform files in the current repository.                             |
+| terraform-workspace            | Selects the Terraform workspace. WORKSPACE must be specified.                    |
+| terraform-output               | Prints Terraform outputs in HCL format. WORKSPACE must be specified.             |
+| terraform-output-json          | Prints Terraform outputs in JSON format. WORKSPACE must be specified.            |
+| terraform-plan                 | Creates a Terraform plan using remote state. WORKSPACE must be specified.        |
+| terraform-plan-destroy-local   | Creates a Terraform destroy plan using local state. WORKSPACE must be specified. |
+| terraform-plan-local           | Creates a Terraform plan using local state. WORKSPACE must be specified.         |
+| terraform-apply                | Applies previously created Terraform plan. WORKSPACE must be specified.          |
+| terraform-refresh              | Refreshes remote Terraform state. WORKSPACE must be specified.                   |
+| terraform-destroy              | Destroys Terraform-managed infrastructure. WORKSPACE must be specified.          |
+| terraform-console              | Launches a Terraform console. WORKSPACE must be specified.                       |
+| terraform-unlock               | Force unlocks the Terraform state. WORKSPACE must be specified.                  |
+|--------------------------------+----------------------------------------------------------------------------------|
+| buildkite-pipeline             | Prints the full generated Buildkite pipeline to stdout.                          |
+| buildkite-pipeline-begin-steps | Prints the beginning portion of the Buildkite pipeline to stdout.                |
+| buildkite-pipeline-check-steps | Prints the lint and validate portion of the Buildkite pipeline to stdout.        |
+| buildkite-pipeline-plan-steps  | Prints the lint and validate portion of the Buildkite pipeline to stdout.        |
+| buildkite-pipeline-apply-steps | Prints the lint and validate portion of the Buildkite pipeline to stdout.        |
+| buildkite-plan-annotate        | Annotates the current Buildkite pipeline with details of the Terraform plan.     |
+|--------------------------------+----------------------------------------------------------------------------------|
+| shell-shfmt                    | Runs shfmt against shell files in the current repository.                        |
+| shell-shellcheck               | Runs shellcheck against shell files in the current repository.                   |
+| shell-lint                     | Runs shfmt and shellcheck against shell files in the current repository.         |
+|--------------------------------+----------------------------------------------------------------------------------|
+| snyk-project                   | Creates a project on the Snyk website for the current repository.                |
+| snyk-app-test                  | Runs a Snyk application test.                                                    |
+| snyk-iac-test                  | Runs a Snyk infrastructure test.                                                 |
++--------------------------------+----------------------------------------------------------------------------------+
 endef
 export HELP
 
@@ -178,8 +182,8 @@ terraform-destroy terraform-console: terraform-ensure-workspace
 ##
 ## Buildkite targets that DO require a workspace
 ##
-.PHONY: buildkite-pipeline
-buildkite-pipeline:
+.PHONY: buildkite-pipeline buildkite-pipeline-begin-steps buildkite-pipeline-check-steps buildkite-pipeline-plan-steps buildkite-pipeline-apply-steps
+buildkite-pipeline buildkite-pipeline-begin-steps buildkite-pipeline-check-steps buildkite-pipeline-plan-steps buildkite-pipeline-apply-steps:
 	@$(call banner,$@)
 	@$(call toolbox,toolbox buildkite "$(@:buildkite-%=%)")
 


### PR DESCRIPTION
This adds some new make targets, that expose some of the component steps
of the existing buildkite-pipeline make target. This allows teams the
option of using the existing full, managed pipeline, or creating their
own pipeline that leverages some of the features and smarts of the
existing pipeline.

Closes #6