### PR TITLE
Make an M1/arm64 compatible toolbox build

### DIFF
--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,0 +1,66 @@
+FROM debian:bullseye-slim
+
+ARG TOOLBOX_VERSION
+ENV TOOLBOX_VERSION="${TOOLBOX_VERSION}"
+ENV TOOLBOX_HOME=/usr/local/share/toolbox
+
+ARG AWSCLI_VERSION=2.2.21
+ARG TERRAFORM_VERSION=1.0.3
+ARG SHELLCHECK_VERSION=0.7.2
+ARG SHFMT_VERSION=3.3.0
+ARG YQ_VERSION=4.9.3
+ARG SCHMA_VERSION=0.0.1
+ARG SNYK_VERSION=1.621.0
+ARG BUILDKITE_AGENT_VERSION=3.32.0
+
+# Install OS packages.
+RUN apt-get update && apt-get install -y bash ca-certificates curl docker git libncurses5-dev libncursesw5-dev openssh-client perl xz-utils zip gzip
+
+# Install AWS CLI
+RUN curl -Lso awscliv2.zip \
+  "https://awscli.amazonaws.com/awscli-exe-linux-aarch64-${AWSCLI_VERSION}.zip" \
+  && unzip -q awscliv2.zip \
+  && ./aws/install
+
+# Install Terraform
+RUN curl -Lso terraform.zip \
+  "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_arm64.zip" \
+  && unzip -q terraform.zip \
+  && mv terraform /usr/local/bin/terraform
+
+# Install shellcheck
+RUN curl -Lso shellcheck.tar.xz \
+  "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.linux.aarch64.tar.xz" \
+  && tar -xf shellcheck.tar.xz \
+  && mv "shellcheck-v${SHELLCHECK_VERSION}/shellcheck" /usr/local/bin/shellcheck
+
+# Install shfmt
+RUN curl -Lso /usr/local/bin/shfmt \
+  "https://github.com/mvdan/sh/releases/download/v${SHFMT_VERSION}/shfmt_v${SHFMT_VERSION}_linux_arm64" \
+  && chmod +x /usr/local/bin/shfmt
+
+# Install yq
+RUN curl -Lso /usr/local/bin/yq \
+  "https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_arm64" \
+  && chmod +x /usr/local/bin/yq
+
+# Install schma
+RUN curl -Lso /usr/local/bin/schma \
+  "https://github.com/seek-oss/schma/releases/download/v${SCHMA_VERSION}/schma-linux-amd64" \
+  && chmod +x /usr/local/bin/schma
+
+# Install Snyk
+RUN curl -Lso /usr/local/bin/snyk \
+  "https://github.com/snyk/snyk/releases/download/v${SNYK_VERSION}/snyk-alpine" \
+  && chmod +x /usr/local/bin/snyk
+
+# Install the buildkite-agent
+RUN curl -Lso buildkite-agent.tar.gz \
+  https://github.com/buildkite/agent/releases/download/v${BUILDKITE_AGENT_VERSION}/buildkite-agent-linux-arm64-${BUILDKITE_AGENT_VERSION}.tar.gz \
+  && tar -xvf buildkite-agent.tar.gz \
+  && mv buildkite-agent /usr/local/bin/buildkite-agent
+
+# Install toolbox
+ADD bin "${TOOLBOX_HOME}/bin"
+ADD lib "${TOOLBOX_HOME}/lib"
+RUN ln -s "${TOOLBOX_HOME}/bin/toolbox.sh" /usr/local/bin/toolbox

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ build:
 	@$(call banner,$@)
 	@docker build \
 		--build-arg TOOLBOX_VERSION=$(RELEASE_VERSION) \
-		-t seek/toolbox:$(RELEASE_VERSION) .
+		-t seek/toolbox:$(RELEASE_VERSION)-amd64 .
 	@docker build \
 		-f Dockerfile.arm64 \
 		--build-arg TOOLBOX_VERSION=$(RELEASE_VERSION) \
@@ -27,8 +27,13 @@ build:
 .PHONY: push
 push:
 	@$(call banner,$@)
-	@docker push seek/toolbox:$(RELEASE_VERSION)
+	@docker push seek/toolbox:$(RELEASE_VERSION)-amd64
 	@docker push seek/toolbox:$(RELEASE_VERSION)-arm64
+	@docker docker manifest create seek/toolbox:$(RELEASE_VERSION) \
+		--amend seek/toolbox:$(RELEASE_VERSION)-amd64 \
+		--amend seek/toolbox:$(RELEASE_VERSION)-arm64
+	@docker docker manifest push seek/toolbox:$(RELEASE_VERSION)
+
 
 ##
 ## Tags and pushes a latest tag for the Toolbox image.
@@ -36,8 +41,13 @@ push:
 .PHONY: push-latest
 push-latest:
 	@$(call banner,$@)
-	@docker tag seek/toolbox:$(RELEASE_VERSION) seek/toolbox:latest
-	@docker push seek/toolbox:latest
+	@docker tag seek/toolbox:$(RELEASE_VERSION)-amd64 seek/toolbox:latest-amd64
+	@docker tag seek/toolbox:$(RELEASE_VERSION)-arm64 seek/toolbox:latest-arm64
+	@docker push seek/toolbox:latest-amd64
+	@docker push seek/toolbox:latest-arm64
+	@docker docker manifest create seek/toolbox:latest \
+		--amend seek/toolbox:$(RELEASE_VERSION)-amd64 \
+		--amend seek/toolbox:$(RELEASE_VERSION)-arm64
 
 ##
 ## Creates a pinned version of toolbox.mk.

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,10 @@ build:
 	@docker build \
 		--build-arg TOOLBOX_VERSION=$(RELEASE_VERSION) \
 		-t seek/toolbox:$(RELEASE_VERSION) .
+	@docker build \
+		-f Dockerfile.arm64 \
+		--build-arg TOOLBOX_VERSION=$(RELEASE_VERSION) \
+		-t seek/toolbox:$(RELEASE_VERSION)-arm64 .
 
 ##
 ## Pushes the Toolbox image to DockerHub.
@@ -24,6 +28,7 @@ build:
 push:
 	@$(call banner,$@)
 	@docker push seek/toolbox:$(RELEASE_VERSION)
+	@docker push seek/toolbox:$(RELEASE_VERSION)-arm64
 
 ##
 ## Tags and pushes a latest tag for the Toolbox image.

--- a/toolbox.mk
+++ b/toolbox.mk
@@ -1,10 +1,14 @@
 # Version of Toolbox to use.
 TOOLBOX_VERSION ?= latest
 
+ifeq ($(shell uname -m),arm64)
+    M1_TAG := -arm64
+endif
+
 # Toolbox Docker image. Default image is exposed as a separate variable to
 # allow importing Makefiles to override TOOLBOX_IMAGE but still retain a
 # reference to the default to use to specify as a base image build arg.
-DEFAULT_TOOLBOX_IMAGE := seek/toolbox:$(TOOLBOX_VERSION)
+DEFAULT_TOOLBOX_IMAGE := seek/toolbox:$(TOOLBOX_VERSION)$(M1_TAG)
 TOOLBOX_IMAGE         ?= $(DEFAULT_TOOLBOX_IMAGE)
 
 # The TOOLBOX_CONFIG_FILE variable can be specified by the caller to override

--- a/toolbox.mk
+++ b/toolbox.mk
@@ -1,14 +1,10 @@
 # Version of Toolbox to use.
 TOOLBOX_VERSION ?= latest
 
-ifeq ($(shell uname -m),arm64)
-    M1_TAG := -arm64
-endif
-
 # Toolbox Docker image. Default image is exposed as a separate variable to
 # allow importing Makefiles to override TOOLBOX_IMAGE but still retain a
 # reference to the default to use to specify as a base image build arg.
-DEFAULT_TOOLBOX_IMAGE := seek/toolbox:$(TOOLBOX_VERSION)$(M1_TAG)
+DEFAULT_TOOLBOX_IMAGE := seek/toolbox:$(TOOLBOX_VERSION)
 TOOLBOX_IMAGE         ?= $(DEFAULT_TOOLBOX_IMAGE)
 
 # The TOOLBOX_CONFIG_FILE variable can be specified by the caller to override


### PR DESCRIPTION
# purpose 
make `toolbox` fully compatible on M1 machines

## things done in this PR
- created a new Dockerfile which contains the arm64 version of Toolbox, with as many dependencies as possible changed to use arm64 versions of the binaries
- updated Makefile targets to build new version
- updated toolbox.mk to have a check for arm64 and switch to that image without any user input 

## important notes
1. as part of this, I've added a new tag for toolbox images, which is just appending `-arm64` at the end of it 
2. the base image for the arm64 version is `debian:bullseye-slim` instead of `alpine`. the reason for this is that the glibc binaries that are installed in the image build process are x86_64 only. this stops an image which is built locally on an M1/arm64 device from working. <br/> <br/> in terms of image size, there seems to be only an increase of ~20mb from switching to the new  base (891MB for arm64 version, 844MB for x86 version)
3. separating into two different Dockerfiles seemed like the nicest way to go about doing this. I thought about having argument to change for the different architectures but tbh it was looking pretty bad - lots of different conditionals etc

