### PR TITLE
Add new command terraform-upgrade

### DIFF
--- a/bin/toolbox.sh
+++ b/bin/toolbox.sh
@@ -41,6 +41,7 @@ case "${_arg_command1}" in
   terraform)
     case "${_arg_command2}" in
       init) tf_init ;;
+      upgrade) tf_upgrade ;;
       workspace) tf_workspace ;;
       lint) tf_lint ;;
       validate) tf_validate ;;

--- a/lib/terraform.sh
+++ b/lib/terraform.sh
@@ -41,6 +41,31 @@ tf_init() {
 }
 
 ##
+## Initialise Terraform with upgrade option.
+##
+tf_upgrade() {
+  if [[ "${_arg_skip_init}" == true ]]; then
+    info_msg "Skipping Terraform initialisation"
+    return 0
+  fi
+
+  info_msg "Initialising Terraform with upgrade"
+
+  local backend_bucket
+  backend_bucket="terraform-$(current_aws_account_id)"
+
+  rm -rf .terraform/terraform.tfstate .terraform/environment
+  terraform init \
+    -upgrade \
+    -backend-config=region="${_tf_global_region}" \
+    -backend-config=bucket="${backend_bucket}" \
+    -backend-config=key=terraform.tfstate \
+    -backend-config=dynamodb_table=terraform >&2
+
+  echo
+}
+
+##
 ## Validate the Terraform files.
 ##
 tf_validate() {

--- a/toolbox.mk
+++ b/toolbox.mk
@@ -153,6 +153,14 @@ terraform-init terraform-validate terraform-lint: $(PRE_TOOLBOX_HOOK)
 	@$(call toolbox,toolbox -s "$(SKIP_INIT)" terraform "$(@:terraform-%=%)")
 
 ##
+## Terraform init with -upgrade option, this DOES NOT require a workspace.
+##
+.PHONY: terraform-upgrade
+terraform-upgrade: $(PRE_TOOLBOX_HOOK)
+	@$(call banner,$@)
+	@$(call toolbox,toolbox -s "$(SKIP_INIT)" terraform "$(@:terraform-%=%)")
+
+##
 ## Ensures that a WORKSPACE variable has been specified.
 ##
 .PHONY: terraform-ensure-workspace

--- a/toolbox.mk
+++ b/toolbox.mk
@@ -78,6 +78,7 @@ define HELP
 |------------------------------+----------------------------------------------------------------------------------|
 | terraform-lint               | Lints Terraform files in the current repository.                                 |
 | terraform-init               | Initialises Terraform.                                                           |
+| terraform-upgrade            | Upgrade Terraform modules and providers with -upgrade option.                                                           |
 | terraform-validate           | Validates Terraform files in the current repository.                             |
 | terraform-workspace          | Selects the Terraform workspace. WORKSPACE must be specified.                    |
 | terraform-output             | Prints Terraform outputs in HCL format. WORKSPACE must be specified.             |


### PR DESCRIPTION
This PR adds `make terraform-upgrade` command to provide a way to upgrade Terraform Providers. The target command essentially run `terraform init -upgrade` to upgrade modules and plugins/providers. 

This has been tested on one of the Cloudflare repo to upgrade Cloudflare provider from 3.4.0 to 3.5.0.
![image](https://user-images.githubusercontent.com/30789036/146705809-ab51e8dc-d15b-4541-a43d-7a2faf7ac579.png)
