### PR TITLE
feat: update aws cli to 2.15.14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,20 @@ ARG BUILDKITE_AGENT_VERSION=3.62.0
 
 # Install OS packages
 RUN apk add --no-cache \
-  aws-cli bash ca-certificates curl docker git jq make ncurses openssh perl xz zip gzip
+  aws-cli --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community \
+  bash \
+  ca-certificates \
+  curl \
+  docker \
+  git \
+  jq \
+  make \
+  ncurses \
+  openssh \
+  perl \
+  xz \
+  zip \
+  gzip
 
 # Install Terraform
 RUN curl -Lsfo terraform.zip \

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,8 @@ RUN apk add --no-cache \
   perl \
   xz \
   zip \
-  gzip
+  gzip \
+  && aws --version
 
 # Install Terraform
 RUN curl -Lsfo terraform.zip \


### PR DESCRIPTION
Upgrading AWS-CLI to 2.15.X which is currently mapped to the `edge` branch for alpine.