### PR TITLE
feat: add env var TOOLBOX_PLAN_ONLY to support plan only pipeline

### DIFF
--- a/toolbox.mk
+++ b/toolbox.mk
@@ -31,6 +31,8 @@ PRE_TOOLBOX_HOOK ?=
 # A default value is set for local testing purposes.
 export BUILDKITE_PIPELINE_SLUG ?= $(shell basename $(shell pwd))
 
+export TOOLBOX_PLAN_ONLY ?= false
+
 # Local build artifacts directory.
 build_dir := target
 
@@ -56,6 +58,7 @@ _toolbox = \
 		-e BUILDKITE_JOB_ID \
 		-e BUILDKITE_AGENT_ACCESS_TOKEN \
 		-e TERM \
+		-e TOOLBOX_PLAN_ONLY \
 		-v "$$(pwd):/work" \
 		-v "$(HOME)/.aws:/root/.aws" \
 		-v "/var/run/docker.sock:/var/run/docker.sock" \


### PR DESCRIPTION
## Problem Statement
Currently, when we try to run the weekly pipeline with `make buildkite-pipeline`, the pipeline will be blocked for a person to review the plan and apply. This is blocking us from increasing the `exercised_pipeline` metrics. The issue seems to be that the toolbox script and pipeline generator (buildkite.sh) does not have the option to run the pipeline without apply.

## Proposed Solution
Extend the toolbox `buildkite.sh` script (and related pipeline generator logic) to support an environment variables as a switch.

When enabled:
- Only generate the Terraform plan local steps in the pipeline.
- Skip all apply/deploy steps.
- Ensure backward compatibility so existing pipelines are unaffected if the flag/variable is not set.