### PR TITLE
Add configurable Terraform deploy pause labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,12 @@ buildkite:
   # "wait". The default is to block.
   deploy_pause_type: block
   # (Optional)
+  # Message text for manual deploy gates between Terraform plan and apply steps.
+  # :rocket: is prepended automatically. Defaults: "Deploy pre-production" and "Deploy production"
+  deploy_pause_labels:
+    non_production: "Deploy terraformed resources to pre-production"
+    production: "Deploy terraformed resources to production"
+  # (Optional)
   # Buildkite artifact management section. This section determines how the Buildkite artifacts plugin
   # (https://github.com/buildkite-plugins/artifacts-buildkite-plugin) should be configured for Terraform
   # plan and apply steps. The "from" and "to" properties below may make use of the ${workspace} variable

--- a/lib/buildkite.sh
+++ b/lib/buildkite.sh
@@ -46,6 +46,17 @@ _bk_wait_step() {
 }
 
 ##
+## Return the deploy block message for non-production or production gates.
+## Config key: buildkite.deploy_pause_labels.non_production | .production
+## The :rocket: prefix is added by _bk_block_step.
+##
+_bk_deploy_pause_label() {
+  local kind="${1}"
+  local default="${2}"
+  config_value "buildkite.deploy_pause_labels.${kind}" "${default}"
+}
+
+##
 ## Print block step.
 ##
 _bk_block_step() {
@@ -299,7 +310,9 @@ _bk_tf_apply_steps() {
   if [[ "${total_non_production_workspaces}" != 0 ]]; then
     local non_production_protected_branches
     non_production_protected_branches="$(_bk_tf_protected_branches_filter '.is_production != true')"
-    _bk_pause_step "Deploy pre-production" "${non_production_protected_branches}"
+    _bk_pause_step \
+      "$(_bk_deploy_pause_label non_production 'Deploy pre-production')" \
+      "${non_production_protected_branches}"
 
     # Apply non-production workspaces.
     _bk_tf_apply_steps_filter '.is_production != true'
@@ -312,7 +325,9 @@ _bk_tf_apply_steps() {
   if [[ "${total_production_workspaces}" != 0 ]]; then
     local production_protected_branches
     production_protected_branches="$(_bk_tf_protected_branches_filter '.is_production == true')"
-    _bk_pause_step "Deploy production" "${production_protected_branches}"
+    _bk_pause_step \
+      "$(_bk_deploy_pause_label production 'Deploy production')" \
+      "${production_protected_branches}"
 
     # Apply production workspaces.
     _bk_tf_apply_steps_filter '.is_production == true'

--- a/lib/schema.json
+++ b/lib/schema.json
@@ -119,6 +119,19 @@
           "type": "string",
           "pattern": "^(block|wait)$"
         },
+        "deploy_pause_labels": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [],
+          "properties": {
+            "non_production": {
+              "type": "string"
+            },
+            "production": {
+              "type": "string"
+            }
+          }
+        },
         "artifacts": {
           "type": "array",
           "items": {


### PR DESCRIPTION
## Summary

Adds optional `buildkite.deploy_pause_labels` in `toolbox.yaml` so projects can customize the message shown on manual deploy gates between Terraform plan and apply steps.

- `non_production` — gate before applying non-production workspaces
- `production` — gate before applying production workspaces

The `:rocket:` prefix is still added by Toolbox. If these keys are omitted, behaviour is unchanged (`Deploy pre-production` / `Deploy production`).

## Motivation

Deploy block labels are generated in Toolbox (`_bk_pause_step` in `lib/buildkite.sh`) and were not configurable per project. Some consumers need clearer, project-specific wording without post-processing generated pipeline YAML (e.g. `sed` in `make buildkite-pipeline`).

## Test plan

- [ ] `make shell-lint` passes
- [ ] `toolbox buildkite pipeline` with no `deploy_pause_labels` → same block labels as today
- [ ] With `deploy_pause_labels` set → custom message with `:rocket:` prefix